### PR TITLE
fix: 解除不必要的继承

### DIFF
--- a/src/Redirect/RedirectMapping.cs
+++ b/src/Redirect/RedirectMapping.cs
@@ -20,7 +20,7 @@ namespace CatLib.ILRuntime.Redirect
     /// <summary>
     /// 重定向映射表
     /// </summary>
-    internal sealed unsafe class RedirectMapping : MonoBehaviour
+    internal sealed unsafe class RedirectMapping
     {
         /// <summary>
         /// 函数签名信息


### PR DESCRIPTION
RedirectMapping 类无需继承自 MonoBehaviour